### PR TITLE
[FIX/53] change logic and flow due to updated API spec with virtual ftting worker

### DIFF
--- a/web-application-server/src/main/java/com/example/webapplicationserver/config/WebClientConfig.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/config/WebClientConfig.java
@@ -1,15 +1,35 @@
 package com.example.webapplicationserver.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
+@Slf4j
 @Configuration
 public class WebClientConfig {
     @Bean
     public WebClient webClient() {
         return WebClient.builder()
-                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)) // 10MB
+                .filter(logRequest())  // 요청 로깅 필터 추가
+                .filter(logResponse()) // 응답 로깅 필터 추가
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024)) // 10MB 설정 유지
                 .build();
+    }
+
+    private ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(request -> {
+            log.info("Request: {} {}", request.method(), request.url());
+            return Mono.just(request);
+        });
+    }
+
+    private ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(response -> {
+            log.info("Response status: {}", response.statusCode());
+            return Mono.just(response);
+        });
     }
 }


### PR DESCRIPTION
### **Description**
This update incorporates changes to the API and logic flow to comply with the new specification for interaction with the virtual fitting worker. The updated API requires sending clothing and model image URLs in a JSON payload instead of multipart form data.

---

### **Key Changes**
1. **WebClient Configuration**:
   - Added request and response logging filters for debugging and tracking API interactions.

2. **Service Logic**:
   - Removed multipart form data processing for model and clothing images.
   - Implemented logic to send clothing and model URLs in JSON format (`Map<String, String>` payload).
   - Updated image processing workflow to adapt to the API changes.

3. **Exception Handling**:
   - Improved error handling for 4xx and 5xx HTTP responses using `onStatus`.

4. **Simplified Workflow**:
   - Replaced redundant logic for image processing and S3 uploads with a streamlined approach.

5. **Refactoring**:
   - Removed outdated methods related to multipart requests.
   - Introduced new methods for JSON payload construction and API communication.

---

### **Implementation Details**
1. **WebClient Logging**:
   - Added `ExchangeFilterFunction` for request and response logging in the `WebClientConfig` class.
   - Ensures detailed logging of outgoing API calls and incoming responses.

   Example logging output:
   ```
   Request: POST http://example.com/inference/
   Response status: 200 OK
   ```

2. **Service Updates**:
   - Replaced multipart upload logic in `uploadImagesAndGetUrlFromFittingServer`:
     ```java
     Map<String, String> requestPayload = new HashMap<>();
     requestPayload.put("clothing", clothImageUrl);
     requestPayload.put("model", fittingModelImageUrl);

     InferenceResponseDto response = webClient.post()
         .uri(targetUri)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(requestPayload)
         .retrieve()
         .bodyToMono(InferenceResponseDto.class)
         .block();
     ```

3. **Post-Fitting Workflow**:
   - After receiving the inference result from the server, the resulting image is uploaded to S3, and the result is saved to the database.

---

### **Testing**
#### **Unit Testing**
- **WebClient Configuration**:
  - Test that requests and responses are logged correctly by verifying log output during API calls.

- **Service Methods**:
  - Validate correct payload structure sent to the AI server.
  - Mock server responses for both success and failure cases (4xx, 5xx).

#### **Integration Testing**
- **End-to-End API Flow**:
  - Simulate the full workflow:
    1. Upload a clothing image and model image to S3.
    2. Call the fitting server with image URLs.
    3. Receive and process the response.
    4. Verify the saved results in the database.

#### **Edge Cases**
- Invalid image URLs (e.g., 404 errors on fetching images).
- Server downtime or unresponsive AI server (e.g., timeouts, 500 errors).
- Large image payloads exceeding memory limits.

