### PR TITLE
[HOTFIX] implement Default Size Recommendation (remove SSE)

### DIFF
--- a/web-application-server/src/main/java/com/example/webapplicationserver/apiPayload/code/status/SuccessStatus.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/apiPayload/code/status/SuccessStatus.java
@@ -17,6 +17,9 @@ public enum SuccessStatus implements BaseCode {
     WIDGET_INFO_OK(HttpStatus.OK, "WIDGET200", "위젯 정보를 성공적으로 불러왔습니다."),
     FILE_UPLOAD_OK(HttpStatus.OK, "FILE201", "파일 업로드가 성공적으로 완료되었습니다."),
     FITTING_RESULT_CREATED(HttpStatus.CREATED, "FITTING202", "가상 피팅 결과가 성공적으로 생성되었습니다."),
+
+    // On Size Chat
+    SIZE_CHAT_CREATED(HttpStatus.CREATED, "SIZE_CHAT202", "사이즈 추천 정보가 성공적으로 생성되었습니다.")
     ;
 
 

--- a/web-application-server/src/main/java/com/example/webapplicationserver/controller/ChatController.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/controller/ChatController.java
@@ -1,32 +1,42 @@
 package com.example.webapplicationserver.controller;
 
+import com.example.webapplicationserver.apiPayload.ApiResponseWrapper;
+import com.example.webapplicationserver.apiPayload.code.status.SuccessStatus;
 import com.example.webapplicationserver.dto.request.widget.RequestSizeChatDto;
-import com.example.webapplicationserver.service.OpenAIStreamService;
+import com.example.webapplicationserver.dto.response.chat.ResponseSizeChatDto;
 
+import com.example.webapplicationserver.service.OpenAIService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Flux;
 
 @Slf4j
 @RestController
 @RequestMapping("/chat")
 @RequiredArgsConstructor
 public class ChatController {
-    private final OpenAIStreamService openAIStreamService;
+    private final OpenAIService openAIService;
 
-    @PostMapping(value = "size", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<String> getSizeStreamChat(
+//    @PostMapping(value = "size", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+//    public Flux<String> getSizeStreamChat(
+//            @RequestBody RequestSizeChatDto requestSizeChatDto
+//    ) {
+//        return openAIStreamService.streamChat(requestSizeChatDto)
+//                .doOnCancel(() -> log.info("Connection canceled by client"))
+//                .doOnComplete(() -> log.info("Streaming completed"))
+//                .doOnError(e -> log.error("Streaming error", e));
+//
+//    }
+
+    @PostMapping(value = "size")
+    public ApiResponseWrapper<ResponseSizeChatDto> getSizeStreamChat(
             @RequestBody RequestSizeChatDto requestSizeChatDto
     ) {
-        return openAIStreamService.streamChat(requestSizeChatDto)
-                .doOnCancel(() -> log.info("Connection canceled by client"))
-                .doOnComplete(() -> log.info("Streaming completed"))
-                .doOnError(e -> log.error("Streaming error", e));
+        ResponseSizeChatDto responseSizeChatDto = openAIService.defaultChat(requestSizeChatDto);
+        return ApiResponseWrapper.onSuccess(SuccessStatus.SIZE_CHAT_CREATED, responseSizeChatDto);
 
     }
 

--- a/web-application-server/src/main/java/com/example/webapplicationserver/controller/WidgetController.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/controller/WidgetController.java
@@ -2,14 +2,12 @@ package com.example.webapplicationserver.controller;
 
 import com.example.webapplicationserver.apiPayload.ApiResponseWrapper;
 import com.example.webapplicationserver.apiPayload.code.status.SuccessStatus;
-import com.example.webapplicationserver.dto.request.widget.RequestSizeChatDto;
 import com.example.webapplicationserver.dto.request.widget.RequestWidgetInfoDto;
 import com.example.webapplicationserver.dto.response.widget.ResponseFittingModelDto;
 import com.example.webapplicationserver.dto.response.widget.ResponseFittingResultDto;
 import com.example.webapplicationserver.dto.response.widget.ResponseWidgetDto;
 import com.example.webapplicationserver.service.FittingModelService;
 import com.example.webapplicationserver.service.FittingService;
-import com.example.webapplicationserver.service.OpenAIStreamService;
 import com.example.webapplicationserver.service.WidgetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,10 +16,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import reactor.core.publisher.Flux;
 
 @RestController
 @RequestMapping("/widget")

--- a/web-application-server/src/main/java/com/example/webapplicationserver/dto/openai/ChatDefaultResponse.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/dto/openai/ChatDefaultResponse.java
@@ -1,0 +1,17 @@
+package com.example.webapplicationserver.dto.openai;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class ChatDefaultResponse {
+    // Getter, Setter
+    private List<Choice> choices;
+
+    // Choice 내부 클래스
+    @Data
+    public static class Choice {
+        private ChatMessage message;
+
+    }
+}

--- a/web-application-server/src/main/java/com/example/webapplicationserver/dto/openai/ChatRequest.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/dto/openai/ChatRequest.java
@@ -8,6 +8,6 @@ import java.util.List;
 public class ChatRequest {
     private String model = "gpt-4o";
     private List<ChatMessage> messages;
-    private boolean stream = true;
+    private boolean stream = false;
     private double temperature = 1;
 }

--- a/web-application-server/src/main/java/com/example/webapplicationserver/dto/response/chat/ResponseSizeChatDto.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/dto/response/chat/ResponseSizeChatDto.java
@@ -1,0 +1,10 @@
+package com.example.webapplicationserver.dto.response.chat;
+
+import com.example.webapplicationserver.dto.openai.ChatDefaultResponse;
+import com.example.webapplicationserver.dto.openai.ChatStreamResponse;
+
+public record ResponseSizeChatDto(
+        String sizeChat
+        ) {
+
+}

--- a/web-application-server/src/main/java/com/example/webapplicationserver/service/OpenAIService.java
+++ b/web-application-server/src/main/java/com/example/webapplicationserver/service/OpenAIService.java
@@ -1,9 +1,11 @@
 package com.example.webapplicationserver.service;
 
+import com.example.webapplicationserver.dto.openai.ChatDefaultResponse;
 import com.example.webapplicationserver.dto.openai.ChatMessage;
 import com.example.webapplicationserver.dto.openai.ChatRequest;
 import com.example.webapplicationserver.dto.openai.ChatStreamResponse;
 import com.example.webapplicationserver.dto.request.widget.RequestSizeChatDto;
+import com.example.webapplicationserver.dto.response.chat.ResponseSizeChatDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,13 +15,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.time.Duration;
 import java.util.List;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class OpenAIStreamService {
+public class OpenAIService {
 
     private final WebClient webClient;
 
@@ -28,6 +29,44 @@ public class OpenAIStreamService {
 
     @Value("${openai.url}")
     private String apiUrl;
+
+    public ResponseSizeChatDto defaultChat(RequestSizeChatDto requestSizeChatDto) {
+        // instruction
+        ChatMessage instruction = new ChatMessage();
+        instruction.setRole("system");
+        instruction.setContent(
+                "다음은 옷의 평균 사이즈야.\n" +
+                        "| SIZE | 가슴둘레   | 어깨너비     | 소매길이     | 총길이        |\n" +
+                        "|------|------------|-------------|--------------|--------------|\n" +
+                        "| 90 S  | 90~96      | 43          | 59.5         | 73           |\n" +
+                        "| 95 M  | 95~100     | 43~45       | 60.5         | 69~74        |\n" +
+                        "| 100 L | 100~104    | 44.5~47     | 61.5~62      | 71~75        |\n" +
+                        "| 105 XL | 105~108    | 46~49       | 62.5~63.5    | 73~76        |\n" +
+                        "| 110 XXL | 110~112   | 47.5~51     | 63.5~65      | 75~77        |\n" +
+                        "사용자한테 일반적인 옷 평균 수치(방금 전에 보낸 값)에 비해 어깨너비나 등등 다 어떻게 다른지해서 오버핏인지 슬림핏인지 그런 것들을 판단해서 서브 메시지를 줘서 사이즈 판단에 도움을 주려해 거기에 필요한 글을 4줄 정도 써줄래? \n" +
+                        "앞에다가 이 부분은 일반적인 사이즈보다는 몇 cm~ 정도는 더 크게 나온 제품이다. 이런 정보도 섞어줄 수 있어?\n" +
+                        "경향은 다 동일하니까 특정 사이즈를 기준으로 말할 필요는 없어."
+        );
+        // 사용자 메시지
+        ChatMessage userInput = new ChatMessage();
+        userInput.setRole("user");
+        userInput.setContent(requestSizeChatDto.content());
+
+        // 요청 객체 생성
+        ChatRequest request = new ChatRequest();
+        request.setMessages(List.of(instruction, userInput));
+
+        ChatDefaultResponse chatDefaultResponse = webClient.post()
+                .uri(apiUrl)
+                .header("Authorization", "Bearer " + apiKey)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ChatDefaultResponse.class)
+                .block();
+
+        return new ResponseSizeChatDto(chatDefaultResponse.getChoices().getFirst().getMessage().getContent());
+
+    }
 
     public Flux<String> streamChat(RequestSizeChatDto requestSizeChatDto) {
         // instruction


### PR DESCRIPTION
### Description
This update enhances the **Chat API** with new capabilities for handling size recommendation requests and adds robust integration with OpenAI services. The changes refactor the existing OpenAI service, introduce new response DTOs, and update controllers to align with the new flow.

---

### Key Changes
1. **Success Status Code Updates**:
   - Added `SIZE_CHAT_CREATED` to signify successful size recommendation creation.
   
2. **Chat Controller Updates**:
   - Refactored the `/chat/size` endpoint to handle both streaming and non-streaming responses.
   - Introduced an updated response format using `ApiResponseWrapper` for consistent API responses.

3. **OpenAI Service Updates**:
   - Created a unified `OpenAIService` for handling both default and streaming chat responses.
   - Added the `defaultChat` method for synchronous size recommendation.

4. **New DTOs**:
   - `ChatDefaultResponse`: Maps the OpenAI API's response structure.
   - `ResponseSizeChatDto`: Provides a clean response format for size chat recommendations.

5. **Refactor**:
   - Moved chat-specific logic from `OpenAIStreamService` to `OpenAIService`.
   - Enhanced error handling with logging for better maintainability.

6. **Miscellaneous Changes**:
   - Removed unused imports and redundant methods from the `WidgetController`.
   - Adjusted the `stream` flag in `ChatRequest` to handle default chat behavior.

---

### Implementation Details
#### 1. **OpenAIService**
Handles communication with the OpenAI API for both streaming and non-streaming scenarios:
- **`defaultChat`**:
  - Prepares and sends a request to OpenAI API.
  - Parses the response into a `ResponseSizeChatDto`.

- **Streaming**:
  - Left unchanged but moved into the new `OpenAIService`.

#### 2. **ChatDefaultResponse DTO**
Maps OpenAI's response:
```java
@Data
public class ChatDefaultResponse {
    private List<Choice> choices;

    @Data
    public static class Choice {
        private ChatMessage message;
    }
}
```

#### 3. **Controller Updates**
- Replaced the redundant `streamChat` endpoint logic with the `defaultChat` implementation in the `ChatController`.

---

### Testing
#### 2. **Integration Tests**:
- Tested `/chat/size` endpoint:
  - Verified success status for valid input.
  - Checked error response consistency for invalid data.

